### PR TITLE
Basic benchmarks for Authorize and Match

### DIFF
--- a/policy_test.go
+++ b/policy_test.go
@@ -89,3 +89,17 @@ func TestAuthorize(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+func BenchmarkAuthorize(b *testing.B) {
+	entity := orn.ORN{
+		Partition:    "foo-company",
+		Service:      "eatService",
+		ResourceType: "food",
+		Resource:     "tomato",
+	}
+
+	for i := 0; i < b.N; i++ {
+		judge.Authorize(policies, entity, "eatService:Take")
+		judge.Authorize(policies, entity, "eatService:BadAction")
+	}
+}

--- a/resource_test.go
+++ b/resource_test.go
@@ -392,3 +392,27 @@ func TestMatch(t *testing.T) {
 		})
 	})
 }
+
+// Benchmarks
+
+func BenchmarkMatch(b *testing.B) {
+	var (
+		entity = orn.ORN{
+			Partition:    "food-company",
+			Service:      "eatService",
+			ResourceType: "food",
+			Resource:     "milk/foo",
+		}
+
+		resource = judge.Resource{
+			Partition:    "food-company",
+			Service:      "eatService",
+			ResourceType: "food",
+			Resource:     "milk/*",
+		}
+	)
+
+	for i := 0; i < b.N; i++ {
+		resource.Match(&entity)
+	}
+}


### PR DESCRIPTION
Start with `go test -bench=. -benchmem`